### PR TITLE
Release/v3.15.0

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -5,22 +5,27 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [10, 12, 14]
+    name: node-${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - name: install peers
         run: npm install @bcgsc-pori/graphkb-parser
       - run: npm test
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.6
-        if: always()
+        if: matrix.node == 12
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage/junit.xml
       - uses: codecov/codecov-action@v1
+        if: matrix.node == 12
         with:
           yml: codecov.yml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphKB Schema
 
-[![codecov](https://codecov.io/gh/bcgsc/pori_graphkb_schema/branch/master/graph/badge.svg?token=0QZTY7RA1R)](https://codecov.io/gh/bcgsc/pori_graphkb_schema) ![build](https://github.com/bcgsc/pori_graphkb_schema/workflows/build/badge.svg?branch=master) [![npm version](https://badge.fury.io/js/%40bcgsc-pori%2Fgraphkb-schema.svg)](https://badge.fury.io/js/%40bcgsc-pori%2Fgraphkb-schema)
+[![codecov](https://codecov.io/gh/bcgsc/pori_graphkb_schema/branch/master/graph/badge.svg?token=0QZTY7RA1R)](https://codecov.io/gh/bcgsc/pori_graphkb_schema) ![build](https://github.com/bcgsc/pori_graphkb_schema/workflows/build/badge.svg?branch=master) [![npm version](https://badge.fury.io/js/%40bcgsc-pori%2Fgraphkb-schema.svg)](https://badge.fury.io/js/%40bcgsc-pori%2Fgraphkb-schema) ![node versions](https://img.shields.io/badge/node-10%20%7C%2012%20%7C%2014-blue)
 
 This is the package which defines the schema logic used to create the database, build the API and GUI.
 It is a dependency of both the API and GUI and uses the parser package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgsc-pori/graphkb-schema",
-  "version": "3.14.3",
+  "version": "3.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgsc-pori/graphkb-schema",
-  "version": "3.14.3",
+  "version": "3.15.0",
   "description": "Shared package between the API and GUI for GraphKB which holds the schema definitions and schema-related functions",
   "bugs": {
     "email": "graphkb@bcgsc.ca"


### PR DESCRIPTION
BugFixes
- bcgsc/pori_graphkb_parser#5 Add support for five-prime cds mutations 