### PR TITLE
Feature/move schema split

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "bugs": {
     "email": "graphkb@bcgsc.ca"
   },
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "NODE_ENV=test jest --config config/jest.config.js --detectOpenHandles --forceExit",
     "jsdoc": "jsdoc -r src -R README.md -d jsdoc -c config/jsdoc.config.js",
-    "lint": "eslint src test --config .eslintrc.json --ext .ts,.tsx --quiet"
+    "lint": "eslint src test --config .eslintrc.json --ext .ts,.tsx --quiet",
+    "build": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,8 @@ import * as constants from './constants';
 import * as sentenceTemplates from './sentenceTemplates';
 
 class SchemaDefinition implements SchemaDefinitionType {
-    schema: Record<string, ClassModel>;
-
-    normalizedModelNames: Record<string, ClassModel>;
+    readonly schema: Record<string, ClassModel>;
+    readonly normalizedModelNames: Record<string, ClassModel>;
 
     constructor(models: Record<string, ClassModel>) {
         this.schema = models;
@@ -24,6 +23,10 @@ class SchemaDefinition implements SchemaDefinitionType {
                 this.normalizedModelNames[model.reverseName.toLowerCase()] = model;
             }
         });
+    }
+
+    get models() {
+        return this.schema;
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,10 +112,15 @@ class SchemaDefinition implements SchemaDefinitionType {
     }
 
     /**
-     * Split class models into an array or with dependencies
-     * will be in an array after the array it depends on
+     * Puts class models into sets of arrays such that all the classes which a given
+     * class refers to (either by inheritance or through a property definition) are in a preceding
+     * array. This is done to facilitate creation of the classes in order so that no class will
+     * reference a class that does not yet exist during its creation
+     *
+     * Note: V, E, User, and UserGroup are special cases and always put in the first level since
+     * they have circular dependencies and are created in a non-standard manner
      */
-    splitClassLevels() {
+    splitClassLevels(): ClassModel[][] {
         const adjacencyList: Record<string, string[]> = {};
 
         // initialize adjacency list

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,10 +112,11 @@ class SchemaDefinition implements SchemaDefinitionType {
     }
 
     /**
-     * Puts class models into sets of arrays such that all the classes which a given
-     * class refers to (either by inheritance or through a property definition) are in a preceding
-     * array. This is done to facilitate creation of the classes in order so that no class will
-     * reference a class that does not yet exist during its creation
+     * Returns the order in which classes should be initialized so that classes which depend on
+     * other classes already exist. i.e the first item in the array will be classes that do not have
+     * any dependencies, followed by classes that only depend on those in the first item. For example if class
+     * Ontology inherits from class V then class V would be in an array preceding the array
+     * containing Ontology.
      *
      * Note: V, E, User, and UserGroup are special cases and always put in the first level since
      * they have circular dependencies and are created in a non-standard manner

--- a/src/model.ts
+++ b/src/model.ts
@@ -84,7 +84,7 @@ export class ClassModel {
 
         this._properties = {}; // by name
 
-        for (const prop of opt.properties || []) {
+        for (const prop of (opt.properties || [])) {
             this._properties[prop.name] = new Property({ ...omit(prop, ['linkedClass']) });
         }
     }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -147,7 +147,9 @@ const BASE_SCHEMA: Record<string, ModelTypeDefinition> = {
  * Given a raw json-like object, initialize the schema definition to add
  * linking between classes and wrapper class/property models
  */
-const initializeSchema = (inputSchema: Record<string, ModelTypeDefinition>) => {
+const initializeSchema = (
+    inputSchema: Record<string, ModelTypeDefinition>,
+): Record<string, ClassModel> => {
     // initialize the models
     const schema = { ...inputSchema };
 
@@ -225,7 +227,7 @@ const initializeSchema = (inputSchema: Record<string, ModelTypeDefinition>) => {
             }
         }
     }
-    return { ...schema, ...models };
+    return models;
 };
 
 const mergeDefinitions = (defns: Record<string, ModelTypeDefinition>[]) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,9 +141,9 @@ export interface GraphRecord {
 }
 
 export interface SchemaDefinitionType {
-    schema: Record<string, ModelType>;
-    normalizedModelNames: Record<string, ModelType>;
-
+    readonly schema: Record<string, ModelType>;
+    readonly normalizedModelNames: Record<string, ModelType>;
+    get models(): Record<string, ModelType>
     has(obj: GraphRecord | string): boolean;
     get(obj: GraphRecord | string): ModelType | null;
     getFromRoute(routeName: string): ModelType;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,6 +53,65 @@ describe('SchemaDefinition', () => {
         expect(names).toContain('E');
         expect(names).not.toContain('V');
     });
+
+    test('splitClassLevels', () => {
+        const levels = SCHEMA_DEFN.splitClassLevels()
+            .map((level) => level.map((model) => model.name).sort());
+
+        expect(levels).toEqual([
+            [
+                'E',
+                'User',
+                'UserGroup',
+                'V',
+            ],
+            [
+                'Biomarker',
+                'Evidence',
+                'LicenseAgreement',
+                'Permissions',
+                'Position',
+                'StatementReview',
+            ],
+            [
+                'CdsPosition',
+                'CytobandPosition',
+                'ExonicPosition',
+                'GenomicPosition',
+                'IntronicPosition',
+                'NonCdsPosition',
+                'ProteinPosition',
+                'RnaPosition',
+                'Source',
+            ],
+            ['Ontology'],
+            [
+                'AliasOf',
+                'AnatomicalEntity',
+                'CatalogueVariant',
+                'Cites',
+                'ClinicalTrial',
+                'CrossReferenceOf',
+                'CuratedContent',
+                'DeprecatedBy',
+                'Disease',
+                'ElementOf',
+                'EvidenceLevel',
+                'Feature',
+                'GeneralizationOf',
+                'OppositeOf',
+                'Pathway',
+                'Publication',
+                'Signature',
+                'SubClassOf',
+                'TargetOf',
+                'Therapy',
+                'Vocabulary',
+            ],
+            ['Abstract', 'Statement', 'Variant'],
+            ['CategoryVariant', 'Infers', 'PositionalVariant'],
+        ]);
+    });
 });
 
 describe('SCHEMA', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     },
     "include": [
         "src",
-        "test"
     ],
     "exclude": [
         "node_modules"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "es2017",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "allowSyntheticDefaultImports": true,
+        "declaration": true,
+        "outDir": "./dist",
+        "strict": true,
+        "noImplicitAny": false,
+        "noEmit": true
+    },
+    "include": [
+        "test",
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,21 +1,9 @@
 {
+    "extends": "./tsconfig.json",
     "compilerOptions": {
-        "target": "es2017",
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "esModuleInterop": true,
-        "isolatedModules": true,
-        "allowSyntheticDefaultImports": true,
-        "declaration": true,
-        "outDir": "./dist",
-        "strict": true,
-        "noImplicitAny": false,
         "noEmit": true
     },
     "include": [
         "test",
-    ],
-    "exclude": [
-        "node_modules"
     ]
 }


### PR DESCRIPTION
- Move the splitting of schema levels by dependencies function from the API to here since it makes more sense
- Add a tsconfig for tests so that getting the package information at run time works
- Add a helper "models" getting to make the usage simpler to read  downstream (schema.schema is confusing)