### PR TITLE
Feature/kbdev 1399 clinicaltrial statement display

### DIFF
--- a/src/sentenceTemplates.ts
+++ b/src/sentenceTemplates.ts
@@ -9,6 +9,7 @@ const TEMPLATE_KEYS = {
     conditions: '{conditions}',
     subject: '{subject}',
     evidence: '{evidence}',
+    evidenceSourceId: '{evidenceSourceId}',
     relevance: '{relevance}',
     evidenceLevel: '{evidenceLevel}',
     preclinicalWarning: '{preclinicalWarning}',
@@ -35,17 +36,19 @@ const DEFAULT_TEMPLATE = `Given ${
  * - evidences
  * - evidence levels
  *
- * @param {string} template string
- * @param {object} record statement record
- * @param {object} [keys=TEMPLATE_KEYS] template key-value pairs
+ * @param {boolean} [opt.evidenceSourceId=false] whether evidenceSourceId is used instead of evidence
+ * @param {object} [opt.keys=TEMPLATE_KEYS] template key-value pairs
+ * @param {object} opt.ecord statement record
+ * @param {string} opt.template string
  *
  * @returns the updated template string
  */
-const addEvidence = (
-    template: string,
-    record: StatementRecord,
+const addEvidence = ({
+    evidenceSourceId = false,
     keys = TEMPLATE_KEYS,
-) => {
+    record,
+    template,
+}) => {
     // remove preexisting evidence info, if any, e.g. from default template
     let updated = template
         .replace(` (${keys.evidenceLevel})`, '')
@@ -69,7 +72,11 @@ const addEvidence = (
     }
 
     // evidences
-    updated += ` (${keys.evidence})`;
+    if (evidenceSourceId) {
+        updated += ` (${keys.evidenceSourceId})`;
+    } else {
+        updated += ` (${keys.evidence})`;
+    }
 
     // evidence levels
     if (record.evidenceLevel) {
@@ -102,49 +109,49 @@ const chooseDefaultTemplate = (record: StatementRecord, keys = TEMPLATE_KEYS) =>
         : '';
 
     if (hasDisease && hasVariant && relevance === 'recurrent') {
-        return addEvidence(
-            `${multiVariant}${keys.variant} is ${keys.relevance} in ${keys.disease}`,
+        return addEvidence({
+            template: `${multiVariant}${keys.variant} is ${keys.relevance} in ${keys.disease}`,
             record,
-        );
+        });
     }
     if (
         subjectType === 'disease'
         && hasVariant
     ) {
         if (relevance === 'diagnostic indicator') {
-            return addEvidence(
-                `${multiVariant}${keys.variant} is ${vowel || 'a'} ${keys.relevance} of ${keys.subject}`,
+            return addEvidence({
+                template: `${multiVariant}${keys.variant} is ${vowel || 'a'} ${keys.relevance} of ${keys.subject}`,
                 record,
-            );
+            });
         }
         if (relevance.includes('diagnos')) {
-            return addEvidence(
-                `${multiVariant}${keys.variant} ${keys.relevance} of ${keys.subject}`,
+            return addEvidence({
+                template: `${multiVariant}${keys.variant} ${keys.relevance} of ${keys.subject}`,
                 record,
-            );
+            });
         }
         if (relevance.includes('predisposing')) {
-            return addEvidence(
-                `${multiVariant}${keys.variant} is ${keys.relevance} to ${keys.subject}`,
+            return addEvidence({
+                template: `${multiVariant}${keys.variant} is ${keys.relevance} to ${keys.subject}`,
                 record,
-            );
+            });
         }
         if (relevance === 'mutation hotspot') {
-            return addEvidence(
-                `${keys.variant} is ${vowel || 'a'} ${keys.relevance} in ${keys.subject}`,
+            return addEvidence({
+                template: `${keys.variant} is ${vowel || 'a'} ${keys.relevance} in ${keys.subject}`,
                 record,
-            );
+            });
         }
         if (relevance === 'tumourigenesis') {
-            return addEvidence(
-                `${multiVariant}${keys.variant} contributes to ${keys.relevance} of ${keys.subject}`,
+            return addEvidence({
+                template: `${multiVariant}${keys.variant} contributes to ${keys.relevance} of ${keys.subject}`,
                 record,
-            );
+            });
         }
-        return addEvidence(
-            `${multiVariant}${keys.variant} is ${keys.relevance} in ${keys.subject}`,
+        return addEvidence({
+            template: `${multiVariant}${keys.variant} is ${keys.relevance} in ${keys.subject}`,
             record,
-        );
+        });
     }
 
     if (subjectType === 'feature' || subjectType.endsWith('variant')) {
@@ -153,15 +160,15 @@ const chooseDefaultTemplate = (record: StatementRecord, keys = TEMPLATE_KEYS) =>
 
         if (isFunctional && hasVariant) {
             if (!hasDisease) {
-                return addEvidence(
-                    `${keys.variant} results in ${keys.relevance} of ${keys.subject}`,
+                return addEvidence({
+                    template: `${keys.variant} results in ${keys.relevance} of ${keys.subject}`,
                     record,
-                );
+                });
             }
-            return addEvidence(
-                `${keys.variant} results in ${keys.relevance} of ${keys.subject} in ${keys.disease}`,
+            return addEvidence({
+                template: `${keys.variant} results in ${keys.relevance} of ${keys.subject} in ${keys.disease}`,
                 record,
-            );
+            });
         }
         let article = '';
 
@@ -172,28 +179,28 @@ const chooseDefaultTemplate = (record: StatementRecord, keys = TEMPLATE_KEYS) =>
         }
 
         if (!hasDisease) {
-            return addEvidence(
-                `${keys.subject} is ${article}${keys.relevance}`,
+            return addEvidence({
+                template: `${keys.subject} is ${article}${keys.relevance}`,
                 record,
-            );
+            });
         }
-        return addEvidence(
-            `${keys.subject} is ${article}${keys.relevance} in ${keys.disease}`,
+        return addEvidence({
+            template: `${keys.subject} is ${article}${keys.relevance} in ${keys.disease}`,
             record,
-        );
+        });
     }
 
     if (subjectType === 'therapy' && hasVariant) {
         if (hasDisease) {
-            return addEvidence(
-                `${multiVariant}${keys.variant} is associated with ${keys.relevance} to ${keys.subject} in ${keys.disease}`,
+            return addEvidence({
+                template: `${multiVariant}${keys.variant} is associated with ${keys.relevance} to ${keys.subject} in ${keys.disease}`,
                 record,
-            );
+            });
         }
-        return addEvidence(
-            `${multiVariant}${keys.variant} is associated with ${keys.relevance} to ${keys.subject}`,
+        return addEvidence({
+            template: `${multiVariant}${keys.variant} is associated with ${keys.relevance} to ${keys.subject}`,
             record,
-        );
+        });
     }
 
     // prognostic statements
@@ -209,40 +216,42 @@ const chooseDefaultTemplate = (record: StatementRecord, keys = TEMPLATE_KEYS) =>
             if (hasDisease) {
                 template += ` in ${keys.disease}`;
             }
-            return addEvidence(
+            return addEvidence({
                 template,
                 record,
-            );
+            });
         }
     }
 
     // eligibility to clinical trials statements
     if (hasVariant && relevance === 'eligibility' && subjectType === 'clinicaltrial') {
         if (hasDisease) {
-            return addEvidence(
-                `Patients with ${multiVariant}${keys.variant} in ${keys.disease} are eligible for ${keys.subject}`,
+            return addEvidence({
+                template: `Patients with ${multiVariant}${keys.variant} in ${keys.disease} are eligible for ${keys.subject}`,
                 record,
-            );
+                evidenceSourceId: true,
+            });
         }
-        return addEvidence(
-            `Patients with ${multiVariant}${keys.variant} are eligible for ${keys.subject}`,
+        return addEvidence({
+            template: `Patients with ${multiVariant}${keys.variant} are eligible for ${keys.subject}`,
             record,
-        );
+            evidenceSourceId: true,
+        });
     }
 
     // default for a single conditions class statement
     if (conditionTypes.length === 1) {
-        return addEvidence(
-            `${keys.subject} is ${keys.relevance}`,
+        return addEvidence({
+            template: `${keys.subject} is ${keys.relevance}`,
             record,
-        );
+        });
     }
 
     // default
-    return addEvidence(
-        DEFAULT_TEMPLATE,
+    return addEvidence({
+        template: DEFAULT_TEMPLATE,
         record,
-    );
+    });
 };
 
 /**
@@ -347,6 +356,13 @@ const generateStatementSentence = (
         const words = record.evidence.map((e) => previewFunc(e));
         highlighted.push(...words);
         substitutions[keys.evidence] = naturalListJoin(words);
+    }
+
+    // add the evidence's sourceId (for clinical trials eligibility; KBDEV-1399)
+    if (replacementsFound.includes(keys.evidenceSourceId) && record.evidence && record.evidence.length) {
+        const words = record.evidence.map((e) => previewFunc({ ...e, displayName: e.sourceId }));
+        highlighted.push(...words);
+        substitutions[keys.evidenceSourceId] = naturalListJoin(words);
     }
 
     // add the evidence level

--- a/src/sentenceTemplates.ts
+++ b/src/sentenceTemplates.ts
@@ -53,6 +53,7 @@ const addEvidence = ({
     let updated = template
         .replace(` (${keys.evidenceLevel})`, '')
         .replace(` (${keys.evidence})`, '')
+        .replace(` (${keys.evidenceSourceId})`, '')
         .replace(` ${keys.preclinicalWarning}`, '');
 
     // preclinical warning

--- a/test/sentenceTemplates.test.ts
+++ b/test/sentenceTemplates.test.ts
@@ -289,16 +289,16 @@ describe('generateStatementSentence', () => {
 
     test('patient with variant in diesase is eligible for trial', () => {
         const key = 'subject:ClinicalTrial|conditions:CategoryVariant;ClinicalTrial;Disease|relevance:eligibility';
-        const result = 'Patients with CD274 increased rna expression in osteosarcoma [DOID:3347] are eligible for NCT02879162';
+        const result = 'Patients with CD274 increased rna expression in osteosarcoma [DOID:3347] are eligible for NCT02879162 (NCT02879162)';
         const { content } = generateStatementSentence(previewFunction, examples[key]);
-        expect(content.replace(' ({evidence})', '')).toEqual(result);
+        expect(content).toEqual(result);
     });
 
     test('patient with variant is eligible for trial', () => {
         const key = 'subject:ClinicalTrial|conditions:ClinicalTrial;PositionalVariant|relevance:eligibility';
         const { content } = generateStatementSentence(previewFunction, examples[key]);
-        const result = 'Patients with ERBB2:p.L755S are eligible for NCT02155621';
-        expect(content.replace(' ({evidence})', '')).toEqual(result);
+        const result = 'Patients with ERBB2:p.L755S are eligible for NCT02155621 (NCT02155621 and NCT02155622)';
+        expect(content).toEqual(result);
     });
 
     test('partial content', () => {
@@ -340,23 +340,48 @@ describe('generateStatementSentence', () => {
 
 describe('addEvidence', () => {
     test('evidence', () => {
-        const updatedTemplate = addEvidence(DEFAULT_TEMPLATE, examples['evidence']);
+        const updatedTemplate = addEvidence({
+            template: DEFAULT_TEMPLATE,
+            record: examples.evidence,
+        });
         const expected = 'Given {conditions}, {relevance} applies to {subject} ({evidence})'
         expect(updatedTemplate).toEqual(expected);
     });
+
+    test('evidenceSourceId', () => {
+        const updatedTemplate = addEvidence({
+            template: DEFAULT_TEMPLATE,
+            record: examples.evidence, // works just fine as example's data for evidenceSourceId
+            evidenceSourceId: true,
+        });
+        const expected = 'Given {conditions}, {relevance} applies to {subject} ({evidenceSourceId})'
+        expect(updatedTemplate).toEqual(expected);
+    });
+
     test('evidenceLevel', () => {
-        const updatedTemplate = addEvidence(DEFAULT_TEMPLATE, examples['evidenceLevel']);
+        const updatedTemplate = addEvidence({
+            template: DEFAULT_TEMPLATE,
+            record: examples.evidenceLevel,
+        });
         const expected = 'Given {conditions}, {relevance} applies to {subject} ({evidence}) ({evidenceLevel})'
         expect(updatedTemplate).toEqual(expected);
     });
+
     test('preclinical warning', () => {
-        const updatedTemplate = addEvidence(DEFAULT_TEMPLATE, examples['preclinicalWarning']);
+        const updatedTemplate = addEvidence({
+            template: DEFAULT_TEMPLATE,
+            record: examples.preclinicalWarning,
+        });
         const expected = 'Given {conditions}, {relevance} applies to {subject} {preclinicalWarning} ({evidence}) ({evidenceLevel})'
         expect(updatedTemplate).toEqual(expected);
     });
+
     test('remove preexisting evidence info', () => {
-        const template = '... {preclinicalWarning} ({evidence}) ({evidenceLevel})'
-        const updatedTemplate = addEvidence(template, examples['evidence']);
+        const template = '... {preclinicalWarning} ({evidence}) ({evidenceSourceId}) ({evidenceLevel})'
+        const updatedTemplate = addEvidence({
+            template,
+            record: examples.evidence,
+        });
         const expected = '... ({evidence})'
         expect(updatedTemplate).toEqual(expected);
     });

--- a/test/testData/statementExamples.json
+++ b/test/testData/statementExamples.json
@@ -871,6 +871,20 @@
         "@rid": "#109:0"
       }
     ],
+    "evidence": [
+      {
+        "@rid": "#123:45",
+        "@class": "Publication",
+        "displayName": "pmid:12345678",
+        "sourceId": "NCT02155621"
+      },
+      {
+        "@rid": "#123:46",
+        "@class": "Publication",
+        "displayName": "pmid:12345679",
+        "sourceId": "NCT02155622"
+      }
+    ],
     "subject": {
       "displayName": "NCT02155621",
       "@class": "ClinicalTrial",
@@ -1759,6 +1773,14 @@
         "displayName": "NCT02879162",
         "@class": "ClinicalTrial",
         "@rid": "#110:6"
+      }
+    ],
+    "evidence": [
+      {
+        "@rid": "#123:45",
+        "@class": "Publication",
+        "displayName": "pmid:12345678",
+        "sourceId": "NCT02879162"
       }
     ],
     "subject": {


### PR DESCRIPTION
See https://www.bcgsc.ca/jira/browse/KBDEV-1399 for issue

Current changes can be added to next minor release, no migration needed.
After release and everything in place (api & client using latest version), datafix needed to regenerate sentence template for CT eligibility statements.
No need for api changes apparently; will test again though.